### PR TITLE
Added some type hints and replaced native matrix math with calls to mikera

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,8 @@
 {:paths ["src"]
  :deps {iglu {:mvn/version "0.2.0"}
-        expound {:mvn/version "0.7.2"}}
+        expound {:mvn/version "0.7.2"}
+        net.mikera/core.matrix {:mvn/version "0.62.0"}
+        net.mikera/vectorz-clj {:mvn/version "0.48.0"}}
  :aliases {:dev {:extra-deps {org.clojure/clojurescript {:mvn/version "1.10.520"}
                               dynadoc {:mvn/version "RELEASE"}
                               com.bhauman/figwheel-main {:mvn/version "0.2.0"}
@@ -21,5 +23,5 @@
                               org.lwjgl/lwjgl-stb$natives-linux {:mvn/version "3.2.1"}
                               org.lwjgl/lwjgl-stb$natives-macos {:mvn/version "3.2.1"}
                               org.lwjgl/lwjgl-stb$natives-windows {:mvn/version "3.2.1"}}
-                 :extra-paths ["dev-resources"]}
+                 :extra-paths ["target" "dev-resources"]}
            :prod {:extra-deps {leiningen {:mvn/version "2.9.0"}}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -23,5 +23,5 @@
                               org.lwjgl/lwjgl-stb$natives-linux {:mvn/version "3.2.1"}
                               org.lwjgl/lwjgl-stb$natives-macos {:mvn/version "3.2.1"}
                               org.lwjgl/lwjgl-stb$natives-windows {:mvn/version "3.2.1"}}
-                 :extra-paths ["target" "dev-resources"]}
+                 :extra-paths ["dev-resources"]}
            :prod {:extra-deps {leiningen {:mvn/version "2.9.0"}}}}}

--- a/dev-resources/play_cljc/gl/example_utils.cljc
+++ b/dev-resources/play_cljc/gl/example_utils.cljc
@@ -103,7 +103,7 @@
 
 (defn get-image [fname callback]
   #?(:clj  (let [is (io/input-stream (io/resource (str "dynadoc-extend/cljs/" fname)))
-                 bytes (with-open [out (java.io.ByteArrayOutputStream.)]
+                 ^bytes bytes (with-open [out (java.io.ByteArrayOutputStream.)]
                          (io/copy is out)
                          (.toByteArray out))
                  *width (MemoryUtil/memAllocInt 1)
@@ -148,4 +148,3 @@
              (MemoryUtil/memFree *height)
              n)
      :cljs (-> game :context .-canvas .-clientHeight)))
-

--- a/src/play_cljc/gl/core.cljc
+++ b/src/play_cljc/gl/core.cljc
@@ -104,10 +104,10 @@
     mat3      (gl game uniformMatrix3fv uni-loc false #?(:clj (float-array data) :cljs data))
     mat4      (gl game uniformMatrix4fv uni-loc false #?(:clj (float-array data) :cljs data))
     sampler2D (assoc-in m [:textures uni-name]
-                        (create-texture game m uni-loc (update data :data
-                                                               (fn [d]
-                                                                 (convert-type game uni-name
-                                                                               (-> data :opts :src-type) d)))))))
+                (create-texture game m uni-loc (update data :data
+                                                 (fn [d]
+                                                   (convert-type game uni-name
+                                                     (-> data :opts :src-type) d)))))))
 
 (defn- get-uniform-type [{:keys [vertex fragment]} uni-name]
   (or (get-in vertex [:uniforms uni-name])
@@ -201,7 +201,7 @@
         uniform-locations (reduce
                             (fn [m uniform]
                               (assoc m uniform
-                                (gl game getUniformLocation program ^String (name uniform))))
+                                (gl game getUniformLocation program (name uniform))))
                             {}
                             (-> #{}
                                 (into (-> vertex :uniforms keys))

--- a/src/play_cljc/gl/core.cljc
+++ b/src/play_cljc/gl/core.cljc
@@ -94,7 +94,7 @@
                       (gl game bindFramebuffer (gl game FRAMEBUFFER) previous-framebuffer)
                       fb))}))
 
-(defn- call-uniform* [game m glsl-type uni-loc uni-name data]
+(defn- call-uniform* [game m glsl-type ^Integer uni-loc uni-name data]
   (case glsl-type
     float     (gl game uniform1f uni-loc #?(:clj (float data) :cljs data))
     vec2      (gl game uniform2fv uni-loc #?(:clj (float-array data) :cljs data))
@@ -104,10 +104,10 @@
     mat3      (gl game uniformMatrix3fv uni-loc false #?(:clj (float-array data) :cljs data))
     mat4      (gl game uniformMatrix4fv uni-loc false #?(:clj (float-array data) :cljs data))
     sampler2D (assoc-in m [:textures uni-name]
-                (create-texture game m uni-loc (update data :data
-                                                 (fn [d]
-                                                   (convert-type game uni-name
-                                                     (-> data :opts :src-type) d)))))))
+                        (create-texture game m uni-loc (update data :data
+                                                               (fn [d]
+                                                                 (convert-type game uni-name
+                                                                               (-> data :opts :src-type) d)))))))
 
 (defn- get-uniform-type [{:keys [vertex fragment]} uni-name]
   (or (get-in vertex [:uniforms uni-name])
@@ -184,7 +184,7 @@
                            (gl game CURRENT_PROGRAM))
         previous-vao (gl game #?(:clj getInteger :cljs getParameter)
                        (gl game VERTEX_ARRAY_BINDING))
-        program (u/create-program game vertex-source fragment-source)
+        ^int program (u/create-program game vertex-source fragment-source)
         _ (gl game useProgram program)
         vao (gl game #?(:clj genVertexArrays :cljs createVertexArray))
         _ (gl game bindVertexArray vao)
@@ -201,7 +201,7 @@
         uniform-locations (reduce
                             (fn [m uniform]
                               (assoc m uniform
-                                (gl game getUniformLocation program (name uniform))))
+                                (gl game getUniformLocation program ^String (name uniform))))
                             {}
                             (-> #{}
                                 (into (-> vertex :uniforms keys))
@@ -286,4 +286,3 @@
         (gl game drawArrays (gl game TRIANGLES) 0 index-count)))
     (gl game useProgram previous-program)
     (gl game bindVertexArray previous-vao)))
-

--- a/src/play_cljc/gl/utils.cljc
+++ b/src/play_cljc/gl/utils.cljc
@@ -26,7 +26,7 @@
 (defn create-buffer
   ([game program attrib-name src-data]
    (create-buffer game program attrib-name src-data {}))
-  ([game ^Integer program ^String attrib-name src-data
+  ([game program attrib-name src-data
     {:keys [size type normalize stride offset]
      :or {normalize false stride 0 offset 0}}]
    (let [attrib-location (gl game getAttribLocation program attrib-name)

--- a/src/play_cljc/gl/utils.cljc
+++ b/src/play_cljc/gl/utils.cljc
@@ -2,11 +2,11 @@
   (:require #?(:clj  [play-cljc.macros-java :refer [gl]]
                :cljs [play-cljc.macros-js :refer-macros [gl]])))
 
-(defn- create-shader [game type source]
+(defn- create-shader [game type ^String source]
   (let [shader (gl game createShader type)]
     (gl game shaderSource shader source)
     (gl game compileShader shader)
-    (if #?(:clj (= (gl game TRUE) (gl game getShaderi shader (gl game COMPILE_STATUS))) 
+    (if #?(:clj (= (gl game TRUE) (gl game getShaderi shader (gl game COMPILE_STATUS)))
            :cljs (gl game getShaderParameter shader (gl game COMPILE_STATUS)))
       shader
       (throw (ex-info (gl game getShaderInfoLog shader) {})))))
@@ -18,7 +18,7 @@
     (gl game attachShader program vertex-shader)
     (gl game attachShader program fragment-shader)
     (gl game linkProgram program)
-    (if #?(:clj (= (gl game TRUE) (gl game getProgrami program (gl game LINK_STATUS))) 
+    (if #?(:clj (= (gl game TRUE) (gl game getProgrami program (gl game LINK_STATUS)))
            :cljs (gl game getProgramParameter program (gl game LINK_STATUS)))
       program
       (throw (ex-info (gl game getProgramInfoLog program) {})))))
@@ -26,7 +26,7 @@
 (defn create-buffer
   ([game program attrib-name src-data]
    (create-buffer game program attrib-name src-data {}))
-  ([game program attrib-name src-data
+  ([game ^Integer program ^String attrib-name src-data
     {:keys [size type normalize stride offset]
      :or {normalize false stride 0 offset 0}}]
    (let [attrib-location (gl game getAttribLocation program attrib-name)
@@ -42,4 +42,3 @@
     (gl game bindBuffer (gl game ELEMENT_ARRAY_BUFFER) index-buffer)
     (gl game bufferData (gl game ELEMENT_ARRAY_BUFFER) indices (gl game STATIC_DRAW))
     (#?(:clj count :cljs .-length) indices)))
-

--- a/src/play_cljc/macros_java.clj
+++ b/src/play_cljc/macros_java.clj
@@ -6,7 +6,7 @@
   lower-case letter, or a static field if it starts with an upper-case letter."
   [n & args]
   (let [s (str n)
-        l (nth s 0)]
+        ^Character l (nth s 0)]
     (if (Character/isUpperCase l)
       (symbol (str 'Math "/" s))
       (cons (symbol (str 'Math "/" s)) args))))
@@ -16,7 +16,7 @@
   lower-case letter, or a static field if it starts with an upper-case letter."
   [_ n & args]
   (let [s (str n)
-        l (nth s 0)
+        ^Character l (nth s 0)
         remaining-letters (subs s 1)]
     (if (Character/isUpperCase l)
       (symbol (str "org.lwjgl.opengl.GL41/GL_" s))
@@ -29,4 +29,3 @@
    (t/transform content))
   ([attrs entity]
    (t/transform-entity attrs entity)))
-

--- a/src/play_cljc/macros_js.clj
+++ b/src/play_cljc/macros_js.clj
@@ -6,7 +6,7 @@
   lower-case letter, or a property if it starts with an upper-case letter."
   [n & args]
   (let [s (str n)
-        l (nth s 0)]
+        ^Character l (nth s 0)]
     (if (Character/isUpperCase l)
       (symbol (str 'js "/Math." s))
       (cons (symbol (str 'js "/Math." s)) args))))
@@ -16,7 +16,7 @@
   lower-case letter, or a static field if it starts with an upper-case letter."
   [game n & args]
   (let [s (str n)
-        l (nth s 0)]
+        ^Character l (nth s 0)]
     (if (Character/isUpperCase l)
       `(goog.object/get (:context ~game) ~s)
       (concat [(symbol (str "." s)) `(:context ~game)] args))))
@@ -27,4 +27,3 @@
    (t/transform content))
   ([attrs entity]
    (t/transform-entity attrs entity)))
-

--- a/src/play_cljc/math.cljc
+++ b/src/play_cljc/math.cljc
@@ -1,6 +1,9 @@
 (ns play-cljc.math
-  (:require #?(:clj  [play-cljc.macros-java :refer [math]]
-               :cljs [play-cljc.macros-js :refer-macros [math]])))
+  (:require #?@(:clj  [[play-cljc.macros-java :refer [math]]
+                       [clojure.core.matrix :as mat]]
+                :cljs [[play-cljc.macros-js :refer-macros [math]]])))
+
+#?(:clj (mat/set-current-implementation :vectorz))
 
 (defn vector->array [v]
   (#?(:clj float-array :cljs clj->js) v))
@@ -8,67 +11,83 @@
 (defn vector->2d-array [v]
   (#?(:clj to-array-2d :cljs clj->js) v))
 
-(defn identity-matrix [size]
-  (vec (for [row (range size)
-             col (range size)]
-         (if (= row col) 1 0))))
+#?(:clj
+   (do
+    (defn identity-matrix [size]
+      (flatten (mat/to-nested-vectors (mat/identity-matrix size))))
 
-(defn multiply-matrices [size m1 m2]
-  (let [m1 (mapv vec (partition size m1))
-        m2 (mapv vec (partition size (or m2 (identity-matrix size))))
-        result (for [i (range size)
-                     j (range size)]
-                 (reduce
-                   (fn [sum k]
-                     (+ sum (* (get-in m1 [i k])
-                               (get-in m2 [k j]))))
-                   0
-                   (range size)))]
-    (vec result)))
+    (defn multiply-matrices [size m1 m2]
+      (let [m1 (mat/array (partition size m1))
+            m2 (mat/array (partition size (or m2 (identity-matrix size))))]
+        (flatten (mat/to-nested-vectors (mat/mmul m1 m2)))))
 
-(defn inverse-matrix [size m]
-  (let [mc (mapv vec (partition size m))
-        mi (mapv vec (for [i (range size)]
-                       (for [j (range size)]
-                         (if (= i j) 1 0))))
-        mc (vector->2d-array mc)
-        mi (vector->2d-array mi)]
-    (dotimes [i size]
-      (when (= 0 (aget mc i i))
-        (loop [r (range (+ i 1) size)]
-          (when-let [ii (first r)]
-            (if (not= 0 (aget mc ii i))
-              (dotimes [j size]
-                (let [e (aget mc i j)]
-                  (aset mc i j (aget mc ii j))
-                  (aset mc ii j e))
-                (let [e (aget mi i j)]
-                  (aset mi i j (aget mi ii j))
-                  (aset mi ii j e)))
-              (recur (rest r))))))
-      (let [e (aget mc i i)]
-        (when (= 0 e)
-          (throw (ex-info "Not invertable" {})))
-        (dotimes [j size]
-          (aset mc i j (/ (aget mc i j) e))
-          (aset mi i j (/ (aget mi i j) e))))
-      (dotimes [ii size]
-        (when (not= i ii)
-          (let [e (aget mc ii i)]
+    (defn inverse-matrix [size m]
+      (let [mc (mat/array (partition size m))]
+        (flatten (mat/to-nested-vectors (mat/inverse mc))))))
+
+   :cljs
+   (do
+    (defn identity-matrix [size]
+      (vec (for [row (range size)
+                col (range size)]
+            (if (= row col) 1 0))))
+
+    (defn multiply-matrices [size m1 m2]
+      (let [m1 (mapv vec (partition size m1))
+            m2 (mapv vec (partition size (or m2 (identity-matrix size))))
+            result (for [i (range size)
+                        j (range size)]
+                    (reduce
+                      (fn [sum k]
+                        (+ sum (* (get-in m1 [i k])
+                                  (get-in m2 [k j]))))
+                      0
+                      (range size)))]
+        (vec result)))
+
+    (defn inverse-matrix [size m]
+      (let [mc (mapv vec (partition size m))
+            mi (mapv vec (for [i (range size)]
+                          (for [j (range size)]
+                            (if (= i j) 1 0))))
+            mc (vector->2d-array mc)
+            mi (vector->2d-array mi)]
+        (dotimes [i size]
+          (when (= 0 (aget mc i i))
+            (loop [r (range (+ i 1) size)]
+              (when-let [ii (first r)]
+                (if (not= 0 (aget mc ii i))
+                  (dotimes [j size]
+                    (let [e (aget mc i j)]
+                      (aset mc i j (aget mc ii j))
+                      (aset mc ii j e))
+                    (let [e (aget mi i j)]
+                      (aset mi i j (aget mi ii j))
+                      (aset mi ii j e)))
+                  (recur (rest r))))))
+          (let [e (aget mc i i)]
+            (when (= 0 e)
+              (throw (ex-info "Not invertable" {})))
             (dotimes [j size]
-              (aset mc ii j
-                (- (aget mc ii j)
-                   (* e (aget mc i j))))
-              (aset mi ii j
-                (- (aget mi ii j)
-                   (* e (aget mi i j)))))))))
-    (->> mi seq (apply concat) vec)))
+              (aset mc i j (/ (aget mc i j) e))
+              (aset mi i j (/ (aget mi i j) e))))
+          (dotimes [ii size]
+            (when (not= i ii)
+              (let [e (aget mc ii i)]
+                (dotimes [j size]
+                  (aset mc ii j
+                    (- (aget mc ii j)
+                      (* e (aget mc i j))))
+                  (aset mi ii j
+                    (- (aget mi ii j)
+                      (* e (aget mi i j)))))))))
+    (->> mi seq (apply concat) vec)))))
 
 (defn deg->rad [d]
   (-> d (* (math PI)) (/ 180)))
 
 (defn transform-vector [m v]
-  (let [dst (vector->array v)]
+  (let [^floats dst (vector->array v)]
     (dotimes [i 4]
       (#?(:clj aset-float :cljs aset) dst i 0.0)
       (dotimes [j 4]
@@ -147,7 +166,7 @@
     [(/ 2 width) 0 0 0
      0 (/ 2 height) 0 0
      0 0 (/ 2 depth) 0
-     
+
      (/ (+ left right)
         (- left right))
      (/ (+ bottom top)
@@ -203,4 +222,3 @@
      (nth y-axis 0) (nth y-axis 1) (nth y-axis 2) 0
      (nth z-axis 0) (nth z-axis 1) (nth z-axis 2) 0
      (nth camera-pos 0) (nth camera-pos 1) (nth camera-pos 2) 1]))
-


### PR DESCRIPTION
Addresses issue #2. 

I wasn't able to figure out how to make the matrix math library work with clojurescript, so I just used reader conditionals like you suggested. I still think it's possible to get mikera to work with clojurescript though, so I might look into it again this weekend. 

It seems like the majority of the speedup comes from replacing the matrix math, but without the type-hints the advanced-render examples are still noticeably choppy. I didn't get rid of all reflection warnings though, I just sorta guessed at which ones were most important. Some of the type-hints may even by wrong, but all the examples still seem to work. 