### PR TITLE
Add -M to command for creating project

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A library for making games that run in both OpenGL and WebGL. There's no black b
 
 You can generate a new project with the [Clojure CLI Tool](https://clojure.org/guides/getting_started#_clojure_installer_and_cli_tools):
 
-`clj -Sdeps "{:deps {leiningen/leiningen {:mvn/version \""2.9.0\""}}}" -m leiningen.core.main new play-cljc hello-world`
+`clj -Sdeps "{:deps {leiningen/leiningen {:mvn/version \""2.9.0\""}}}" -M -m leiningen.core.main new play-cljc hello-world`
 
 This will start you off with a little platformer. It will contain a README with all the commands you need to use.
 


### PR DESCRIPTION
This avoids a warning in later clj versions: `WARNING: Implicit use of clojure.main with options is deprecated, use -M`.